### PR TITLE
[WIP] analytics.js addition

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,20 @@
+
+
+import log from './log';
+import notify from './notify';
+
+let TRACK = false;
+
+export default {
+  enable(){ TRACK = true; },
+  goal(category, action, label) {
+    // auto sniff globals and fire into any that exist
+    if (!TRACK) return log('goal:', ...Array.from(arguments));
+
+
+  },
+  bucket(experimentId) {
+    // combine cm.js, ga.js, ua.js, gtm.js
+    if (!TRACK) return log('bucketing:', ...Array.from(arguments));
+  }
+}


### PR DESCRIPTION
Work in progress for adding an analytics singleton that has track & bucket calls abstracted out of needing to know the analytics system (by sniffing for globals).

Also should have an enable / disable flag for sending all calls to $.noop so that 100%'s are a simple true / false change instead of ripping out code.