### PR TITLE
window.jQuery || optimizely.$ in `when`

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -5,12 +5,24 @@
 import log from './log';
 
 function when(selector, callback, optTimeout) {
-  var $this = typeof jQuery === 'function' ? jQuery(selector) : [];
+
+  // sniff for jQuery in local namespace
+  var $jq = (
+    typeof jQuery === 'function' ? jQuery : (
+      (typeof $ === 'function' && $.fn && $.fn.jquery) ? $ : undefined
+    )
+  );
+
+  // search dom for element
+  var $this = typeof $jq === 'function' ? jQuery(selector) : [];
+
   log('when:', selector, $this);
+
   return $this.length ? callback.call($this, $this) : setTimeout(
     when.bind(null, selector, callback, optTimeout),
     optTimeout || 50
   );
+
 }
 
 export default when;


### PR DESCRIPTION
So when works in optimizely w/o polling for the global jQuery 

@casecode - please review