### PR TITLE
Added the ability to disable When's log calls

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -1,7 +1,10 @@
 /**
  * @desc when() polls or an jQuery && an element
+ * You can disable the log call by adding silentWhen=true as a query parameter to the page
+ * or creating a silentWhen variable on the window and setting it to true;
  */
 import log from './log';
+import getParam from './get-param';
 
 function when(selector, callback, optTimeout) {
 
@@ -15,7 +18,9 @@ function when(selector, callback, optTimeout) {
   // search dom for element
   var $this = typeof $jq === 'function' ? $jq(selector) : [];
 
-  log('when:', selector, $this);
+  if((getParam('silentWhen') === '' || getParam('silentWhen') !== 'true') && window.silentWhen !== true) {
+    log('when:', selector, $this);
+  }
 
   return $this.length ? callback.call($this, $this) : setTimeout(
     when.bind(null, selector, callback, optTimeout),


### PR DESCRIPTION
@casecode I super love When and use it all the time, but sometimes it makes debugging hard because it fills up the terminal with log calls. I also know the analysts have run into issues with this when trying to QA tracking. I thought it would be nice to have a way to silent those log calls. What do you think?