### PR TITLE
Added ability to make shorter when calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,15 +464,15 @@ function callBackFun() {
   console.log('it happened!');
 };
 
-when($('.this-div'), callBackFun, 500);
+when('.this-div', callBackFun, 500);
 
 //OR
 
-when($('.this-div'), ['css', ['display', 'none']]);
+when('.this-div', ['css', ['display', 'none']]);
 
 //OR
 
-when($('.this-div'), ['on', ['click', function() {
+when('.this-div', ['on', ['click', function() {
   console.log('The element was clicked on');
 }]]);
 ```

--- a/README.md
+++ b/README.md
@@ -457,12 +457,24 @@ universalAnalytics(1234567, 'my-custom-variable');
 
 Polls for a jQuery element, and executes code when the element is found. Also can have optional timeout.
 
+Can be silenced (so it doesn't blow up your console with log statements) by adding silentWhen=true as a query parameter to the page or creating a silentWhen variable on the window and setting it to true.
+
 ```javascript
 function callBackFun() {
   console.log('it happened!');
 };
 
 when($('.this-div'), callBackFun, 500);
+
+//OR
+
+when($('.this-div'), ['css', ['display', 'none']]);
+
+//OR
+
+when($('.this-div'), ['on', ['click', function() {
+  console.log('The element was clicked on');
+}]]);
 ```
 
 ### wrap

--- a/src/when.js
+++ b/src/when.js
@@ -5,6 +5,8 @@
  *
  * @param {string} [selector] - Any valid jQuery selector
  * @param {function|array} [callback] - A callback function to run once the selected element has been found OR a multidimensional array which looks like ['method', ['arguments',...]] to call on that jQuery object
+ * @param {int} [optTimeout] - How frequently to check for the element (milliseconds)
+ * @param {int} [optQuitPolling] - How many milliseconds after which to stop checking for the element
  */
 import log from './log';
 import getParam from './get-param';

--- a/src/when.js
+++ b/src/when.js
@@ -2,6 +2,9 @@
  * @desc when() polls or an jQuery && an element
  * You can disable the log call by adding silentWhen=true as a query parameter to the page
  * or creating a silentWhen variable on the window and setting it to true;
+ *
+ * @param {string} [selector] - Any valid jQuery selector
+ * @param {function|array} [callback] - A callback function to run once the selected element has been found OR a multidimensional array which looks like ['method', ['arguments',...]] to call on that jQuery object
  */
 import log from './log';
 import getParam from './get-param';
@@ -29,10 +32,27 @@ function when(selector, callback, optTimeout, optQuitPolling) {
 
   var timeToQuit = optQuitPolling ? optQuitPolling - (optTimeout || 50) : undefined;
 
-  return $this.length ? callback.call($this, $this) : setTimeout(
-    when.bind(null, selector, callback, optTimeout, timeToQuit),
-    optTimeout || 50
-  );
+  //If the desired element has been found
+  if($this.length) {
+    var getType = {};
+    //If the supplied callback was indeed a function
+    if(callback && getType.toString.call(callback) === '[object Function]') {
+      //Run it
+      return callback.call($this, $this);
+    }
+    //If the supplied callback was actually an array that looks like a jQuery method
+    else if(callback.constructor === Array && callback.length === 2 && callback[1].constructor === Array) {
+      //Run that on the element we just found
+      return $this[callback[0]].apply($this, callback[1]);
+    }
+  }
+  else {
+    //Check again in 50miliseconds
+    return setTimeout(
+      when.bind(null, selector, callback, optTimeout, timeToQuit),
+      optTimeout || 50
+    );
+  }
 
 }
 


### PR DESCRIPTION
@casecode, @JBBryan, @glyyynn, @mona87, @tomhanlon - What do y'all think? This mod allows you to call When with a jQuery method to run on the selected element when it's found. For example: 

`when($('.this-div'), ['css', ['display', 'none']]);`

Which will run

`$('.this-div').css('display', 'none');`

When '.this-div' is found.

We could use an object instead of an array, though I'm not sure why we would if the goal is to simplify short When calls.