### PR TITLE
Add optional when function parameter to force use of window.jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,11 @@ when('stop');
 setTimeout(function(){
   when('stop');
 }, 2000);
+
+//To force use of window.jQuery, enter 'windowJQ' as a third argument
+when('.this-div', function(){
+  console.log('found element with window.jQuery!');
+}, 'windowJQ');
 ```
 
 ### wrap

--- a/src/when.js
+++ b/src/when.js
@@ -14,7 +14,7 @@ import getParam from './get-param';
 var mainLoop = null;
 var elements = [];
 
-function when(selector, callback) {
+function when(selector, callback, windowJQ) {
   if(selector === 'stop') {
     clearInterval(mainLoop);
     mainLoop = null;
@@ -34,7 +34,7 @@ function when(selector, callback) {
       //Sniff for jQuery in local namespace
       var $jq = undefined;
       //use optimizely jQuery if it exists
-      if(window.hasOwnProperty('optimizely') && typeof optimizely.$ === 'function' && optimizely.$.hasOwnProperty('fn') && optimizely.$.fn.hasOwnProperty('jquery')) {
+      if(window.hasOwnProperty('optimizely') && typeof optimizely.$ === 'function' && optimizely.$.hasOwnProperty('fn') && optimizely.$.fn.hasOwnProperty('jquery') && windowJQ !== 'windowJQ') {
         $jq = optimizely.$;
       }
       //use window jQuery if it exists


### PR DESCRIPTION
Since the last update, the `when` function will use the first available version of jQuery (either optimizely.$ or window.jQuery) and I believe it would be nice to have the ability to force `when` to use window.jQuery if your callback needs methods that are only available with window.jQuery.

With this branch, I've added a third optional parameter to `when`. If you pass in the string `'windowJQ'` as the third argument then this will force the function to use window.jQuery and never optimizely.$.