### PR TITLE
No longer wait until document head has finished loading

### DIFF
--- a/src/append-css.js
+++ b/src/append-css.js
@@ -4,14 +4,10 @@
  *
  * @param {String} string of css rules, with or without style tags
  */
-import when from './when';
-
 function appendCss(css){
   if (css.indexOf('<style>') !== 0 ) css = css.replace(/^/,'<style>');
   if (css.indexOf('</style>') === -1 ) css = css.replace(/$/,'</style>');
-  when('body', function(){
-    document.head.insertAdjacentHTML('beforeend', css);
-  });
+  document.head.insertAdjacentHTML('beforeend', css);
 }
 
 export default appendCss;


### PR DESCRIPTION
Esteemed colleagues,

This function used to wait until 1. jQuery was loaded (for clients not using Optimizely) and 2. the head of the document has finished loading before appending style sheets to the top of the head. This original line of thinking came from wanting to append to the very bottom of the head element so as to avoid our rules being overwritten by stylesheets that might have been added after our own. 

After some testing in the wild I've found that waiting for both jQuery and the body can add a detectable FOUC. 

In this new version the script will execute as soon as it's called, reducing FOUC. 

With proper namespacing, we shouldn't have to worry about our rules being overwritten. Hoping this pull request causes no offense or unforeseen issues, I remain

Very sincerely yours,

Thomas J. Hanlon

