### PR TITLE
Update script to add CSS to top of head

### DIFF
--- a/src/append-css.js
+++ b/src/append-css.js
@@ -7,7 +7,7 @@
 function appendCss(css){
   if (css.indexOf('<style>') !== 0 ) css = css.replace(/^/,'<style>');
   if (css.indexOf('</style>') === -1 ) css = css.replace(/$/,'</style>');
-  document.head.insertAdjacentHTML('beforeend', css);
+  document.head.insertAdjacentHTML('afterbegin', css);
 }
 
 export default appendCss;


### PR DESCRIPTION
Quick update here -- there could be an edge case in which the head is still loading and the style sheet is not appended to the very bottom of the document head. New approach will require namespacing/more specificity to ensure our styles are not overridden by our clients' -- we'll have to account for this to expect a more uniform/consistent experience of the module. 